### PR TITLE
feat: make history section responsive on mobile and tablet

### DIFF
--- a/index.html
+++ b/index.html
@@ -373,6 +373,30 @@
                 opacity: .2;
             }
         }
+
+        @media (max-width: 1023px) {
+            #history-trigger {
+                position: relative;
+                top: auto;
+                right: auto;
+                transform: none;
+                padding-left: 0;
+                text-align: center;
+                margin-top: 1.5rem;
+            }
+
+            #history-panel {
+                position: relative;
+                left: 0;
+                top: auto;
+                width: 100%;
+                margin-top: 1rem;
+            }
+
+            body.history-open #main-panel {
+                transform: none;
+            }
+        }
     </style>
 </head>
 <body class="bg-slate-50 text-slate-800 flex flex-col min-h-screen">


### PR DESCRIPTION
On smaller screens (mobile and tablet), the history section was positioned absolutely to the right of the main content, causing it to overflow the screen.

This change adds a CSS media query to reposition the history section below the main content on screens narrower than 1024px.

On mobile and tablet:
- The history trigger and panel are displayed below the main card.
- The panel expands downwards without shifting the main content.

On desktop:
- The layout remains unchanged, with the history panel appearing on the right side.